### PR TITLE
fix: correct baseurl and publications link for personal site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 
 title: Jierui Zuo # the website title (if blank, full name will be used instead)
 first_name: Jierui
-middle_name: (Jerry) 
+middle_name: (Jerry)
 last_name: Zuo
 contact_note: >
   You can even add a little note about which of these is the best way to reach you.
@@ -19,7 +19,7 @@ lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
 url: https://zuojr.github.io # the base hostname & protocol for your site
-baseurl: /al-folio # the subpath of your site, e.g. /blog/. Leave blank for root
+baseurl: # the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
 back_to_top: true # set to false to disable the back to top button

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -29,6 +29,6 @@ latest_posts:
 
 Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](https://www.reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.jpg` and put it in the `img/` folder.
 
-Put your address / P.O. box / other info right below your picture. You can also disable any of these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
+Put your address / P.O. box / other info right below your picture. You can also disable any of these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page]({{ '/publications/' | relative_url }}) automatically.
 
 Link to your social media connections, too. This theme is set up to use [Font Awesome icons](https://fontawesome.com/) and [Academicons](https://jpswalsh.github.io/academicons/), like the ones below. Add your Facebook, Twitter, LinkedIn, Google Scholar, or just disable all of them.


### PR DESCRIPTION
### Motivation
- The site was deployed as a personal site but `_config.yml` used `/al-folio` as `baseurl`, which caused asset and page URLs to point to the wrong subpath and made the site appear unstyled.
- A hard-coded publications link in the About page referenced `/al-folio/publications/`, which will break when `baseurl` differs between environments.

### Description
- Set `baseurl` to empty in `_config.yml` so URLs are generated for a root personal-site deployment (`https://zuojr.github.io`).
- Replaced the hard-coded `/al-folio/publications/` link in `_pages/about.md` with `{{ '/publications/' | relative_url }}` so the publications link resolves correctly across environments.
- Normalized a small whitespace in the `middle_name` field of `_config.yml`.

### Testing
- Ran `npx prettier _config.yml _pages/about.md --write` and formatting completed successfully.
- Attempted `bundle exec jekyll build` in this environment and it failed with `bundler: command not found: jekyll`, so a full Jekyll build was not possible here; please validate with a local Docker/Jekyll build (`docker compose up --build`) or CI, which will run the full site build automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d891272e30832cb4e0886f84ecb2a2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/content changes that only affect generated URLs and navigation; potential impact is limited to site routing if the deployment path differs from expectations.
> 
> **Overview**
> Fixes broken styling/links for a root-deployed GitHub Pages site by clearing `baseurl` in `_config.yml` (instead of `/al-folio`).
> 
> Updates the About page’s publications link to use `relative_url` rather than a hard-coded `/al-folio/publications/`, and normalizes minor whitespace in `middle_name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3320b0dd808644c4262fa1073948dc054d68e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->