### PR TITLE
Add new bibliography entries, add generic Paper link, and guard bibtex filter config

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,6 +1,30 @@
 ---
 ---
 
+@misc{agents2026last,
+  title       = {Agents Last Exam},
+  author      = {Zuo, Jierui and others},
+  year        = {2026},
+  note        = {Under review at NeurIPS 2026},
+  selected    = {true}
+}
+
+@article{zhang2026ddorm,
+  title         = {DDO-RM: Distribution-Level Policy Improvement after Reward Learning},
+  author        = {Zhang, Tiantian and Zuo, Jierui and Chen, Michael and Wang, Wenping},
+  year          = {2026},
+  journal       = {arXiv preprint},
+  eprint        = {2604.11119},
+  arxiv         = {2604.11119},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.ML},
+  url           = {https://arxiv.org/abs/2604.11119},
+  doi           = {10.48550/arXiv.2604.11119},
+  pdf           = {https://arxiv.org/pdf/2604.11119},
+  code          = {https://github.com/zuojr/ddorm-llm-preference-benchmark},
+  selected      = {true}
+}
+
 @article{zuo2025pareto,
   title         = {On Pareto Optimality for Parametric Choice Bandits},
   author        = {Zuo, Jierui and Qin, Hanzhang},
@@ -10,6 +34,8 @@
   archiveprefix = {arXiv},
   primaryclass  = {cs.LG},
   url           = {https://arxiv.org/abs/2501.19277},
+  arxiv         = {2501.19277},
+  pdf           = {https://arxiv.org/pdf/2501.19277},
   selected      = {true},
   bibtex_show   = {true}
 }
@@ -34,7 +60,8 @@
   title       = {Learning to Delegate with Costly Audit},
   author      = {Zuo, Jierui and Wang, Yingfei},
   year        = {2026},
-  note        = {Working paper},
+  note        = {Under review at NeurIPS 2026},
+  selected    = {true},
   bibtex_show = {true}
 }
 

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -206,6 +206,9 @@
       {% if entry.hal %}
         <a href="https://hal.science/{{ entry.hal }}" class="btn btn-sm z-depth-0" role="button">HAL</a>
       {% endif %}
+      {% if entry.url and entry.arxiv == blank and entry.pdf == blank and entry.html == blank %}
+        <a href="{{ entry.url }}" class="btn btn-sm z-depth-0" role="button">Paper</a>
+      {% endif %}
       {% if entry.bibtex_show %}
         <a class="bibtex btn btn-sm z-depth-0" role="button">Bib</a>
       {% endif %}

--- a/_plugins/hide-custom-bibtex.rb
+++ b/_plugins/hide-custom-bibtex.rb
@@ -1,11 +1,11 @@
 module Jekyll
   module HideCustomBibtex
     def hideCustomBibtex(input)
-	    keywords = @context.registers[:site].config['filtered_bibtex_keywords']
+      keywords = @context.registers[:site].config['filtered_bibtex_keywords'] || []
 
-	    keywords.each do |keyword|
-		    input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')
-	    end
+      keywords.each do |keyword|
+        input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')
+      end
 
       # Clean superscripts in author lists
       input = input.gsub(/^.*\bauthor\b *= *\{.*$\n/) { |line| line.gsub(/[*†‡§¶‖&^]/, '') }


### PR DESCRIPTION
### Motivation
- Add several new bibliography records and improve metadata for existing entries so new/under-review papers are listed with proper links and flags.
- Provide a generic `Paper` link when an entry has a `url` but no `arxiv`, `pdf`, or `html` so external papers are discoverable from the bibliography.
- Prevent errors when the site config lacks `filtered_bibtex_keywords` by making the bibtex filter resilient to a missing value.

### Description
- Added new `.bib` entries (`agents2026last`, `zhang2026ddorm`) and updated existing entries with `arxiv`, `pdf`, `doi`, `selected`, and `note` fields as appropriate in `_bibliography/papers.bib`.
- Updated `_layouts/bib.liquid` to render a `Paper` button link when `entry.url` exists and `entry.arxiv`, `entry.pdf`, and `entry.html` are blank by adding a conditional `Paper` anchor.
- Hardened `_plugins/hide-custom-bibtex.rb` by defaulting `filtered_bibtex_keywords` to `[]` to avoid `nil` errors, normalized indentation, and retained the author superscript-cleaning regex.

### Testing
- Ran the site build with `bundle exec jekyll build` which completed successfully and produced the bibliography output without errors.
- Verified that pages containing bibliography entries render the new `Paper` button conditionally during the automated build (no build-time errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0208d5b18c832cb00df81643f6f819)